### PR TITLE
[R-4871] Pin black version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/tdeboissiere/python-format-action"
 LABEL "homepage"="https://github.com/tdeboissiere/python-format-action"
 LABEL "maintainer"="tdeboissier"
 
-RUN pip install black reorder-python-imports==3.10.0
+RUN pip install black==23.11.0 reorder-python-imports==3.10.0
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
because the newer versions complain about blank lines introduced by reorder-python-imports.